### PR TITLE
Fix incorrect call to 'path.delimiter'

### DIFF
--- a/lib/linter-kotlin.coffee
+++ b/lib/linter-kotlin.coffee
@@ -26,12 +26,12 @@ class LinterKotlin
 			cp = cpConfig.cfgCp
 
 		cp =  if @classpath
-			if cp? then "#{cp}#{path.delimeter}#{@classpath}" else @classpath
+			if cp? then "#{cp}#{path.delimiter}#{@classpath}" else @classpath
 		else
 			cp
 
 		cp = if process.env.CLASSPATH
-			if cp? then "#{cp}#{path.delimeter}#{process.env.CLASSPATH}" else process.env.CLASSPATH
+			if cp? then "#{cp}#{path.delimiter}#{process.env.CLASSPATH}" else process.env.CLASSPATH
 		else
 			cp
 


### PR DESCRIPTION
Prior to this, it was path.delimeter, which produced the path to contain 'undefined' along with no path separation.

This allows a custom path through .atom_jvm_classpath to work correctly.